### PR TITLE
make rust code more idiomatic

### DIFF
--- a/src/helpers/testing.rs
+++ b/src/helpers/testing.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! Helpers for unit testing.
 
 use std::collections::{HashMap, HashSet};
@@ -129,7 +128,7 @@ pub fn test_captures(query: &str, input: &str) {
         }
     });
     for ((row, col), set) in test_specs {
-        for label in set {
+        if let Some(label) = set.iter().next() {
             panic!("Expected @{} at row {} column {}", label, row, col);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,5 +91,5 @@ fn main() -> ExitCode {
         }
     }
 
-    return ExitCode::SUCCESS;
+    ExitCode::SUCCESS
 }

--- a/src/rules/api.rs
+++ b/src/rules/api.rs
@@ -26,5 +26,6 @@ pub trait Rule {
     /// - `filename`: Name of the file being checked.
     /// - `tree`: [`Tree`] representing the file.
     /// - `code`: Text/code of the given file.
+    #[must_use]
     fn check(&self, tree: &Tree, code: &[u8]) -> Vec<Diagnostic<()>>;
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 pub mod api;
 pub mod rule1a;
 pub mod rule1b;
@@ -21,6 +20,7 @@ pub mod rule1d;
 
 use self::api::Rule;
 
+#[must_use]
 /// Returns a [Vec] of all [rules][Rule].
 pub fn get_rules() -> Vec<Box<dyn Rule>> {
     vec![

--- a/src/rules/rule1a.rs
+++ b/src/rules/rule1a.rs
@@ -36,7 +36,7 @@ use tree_sitter::Tree;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
 
-const QUERY_STR: &'static str = indoc! { /* query */ r#"
+const QUERY_STR: &str = indoc! { /* query */ r#"
     (
         [
             (_ declarator: [

--- a/src/rules/rule1b.rs
+++ b/src/rules/rule1b.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! # Rule I:B
 //!
 //! ```text
@@ -48,6 +47,6 @@ pub struct Rule1b {}
 
 impl Rule for Rule1b {
     fn check(&self, _tree: &Tree, _code: &[u8]) -> Vec<Diagnostic<()>> {
-        return Vec::with_capacity(0);
+        Vec::with_capacity(0)
     }
 }

--- a/src/rules/rule1c.rs
+++ b/src/rules/rule1c.rs
@@ -45,7 +45,7 @@ use tree_sitter::{QueryCapture, Tree};
 use crate::{helpers::QueryHelper, rules::api::Rule};
 
 /// Tree-sitter query for Rule I:C.
-const QUERY_STR: &'static str = indoc! { /* query */ r#"
+const QUERY_STR: &str = indoc! { /* query */ r#"
     (
         (preproc_def name: (identifier) @constant.name.short)
         (#match? @constant.name.short "^.$")

--- a/src/rules/rule1d.rs
+++ b/src/rules/rule1d.rs
@@ -37,7 +37,7 @@ use tree_sitter::{QueryCapture, Tree};
 use crate::{helpers::QueryHelper, rules::api::Rule};
 
 /// Tree-sitter query for Rule I:D.
-const QUERY_STR: &'static str = indoc! {
+const QUERY_STR: &str = indoc! {
     /* query */
     r#"
     (


### PR DESCRIPTION
Several changes are made to ensure that rust idioms are more closely followed; a few of these were suggested by `clippy` (hence the branch name).