### PR TITLE
Update codespan dependency to v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,13 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -391,12 +392,6 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
@@ -419,7 +414,7 @@ dependencies = [
  "pretty_assertions",
  "tree-sitter",
  "tree-sitter-c",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cc = "*"
 [dependencies]
 clap = { version = "4.5.31", features = ["cargo", "derive"] }
 clap-stdin = "0.6.0"
-codespan-reporting = "0.11.1"
+codespan-reporting = "0.12.0"
 indoc = "2.0.6"
 tree-sitter = "0.25.3"
 tree-sitter-c = "0.23.4"

--- a/src/rules/rule1a.rs
+++ b/src/rules/rule1a.rs
@@ -80,16 +80,16 @@ impl Rule for Rule1a {
             let diagnostic = Diagnostic::warning()
                 .with_message(format!("{} names must be in lower snake case.", nametype))
                 .with_code("I:A")
-                .with_labels(vec![
+                .with_label(
                     Label::primary((), capture.node.byte_range())
                         .with_message("Name contains uppercase character(s)"),
-                    Label::secondary((), capture.node.byte_range()).with_message(format!(
-                        "Perhaps you meant `{}'",
-                        guess_lower_snake_case(
-                            capture.node.utf8_text(code).expect("Code is not valid UTF-8")
-                        )
-                    )),
-                ]);
+                )
+                .with_label(Label::secondary((), capture.node.byte_range()).with_message(format!(
+                    "Perhaps you meant `{}'",
+                    guess_lower_snake_case(
+                        capture.node.utf8_text(code).expect("Code is not valid UTF-8")
+                    )
+                )));
             diagnostics.push(diagnostic);
         });
         diagnostics

--- a/src/rules/rule1c.rs
+++ b/src/rules/rule1c.rs
@@ -89,10 +89,10 @@ impl Rule for Rule1c {
                 ),
                 _ => unreachable!(),
             };
-            let mut diagnostic =
-                Diagnostic::warning().with_code("I:C").with_message(message).with_labels(vec![
-                    Label::primary((), capture.node.byte_range()).with_message(label),
-                ]);
+            let mut diagnostic = Diagnostic::warning()
+                .with_code("I:C")
+                .with_message(message)
+                .with_label(Label::primary((), capture.node.byte_range()).with_message(label));
             if let Some(fix) = fix {
                 diagnostic.labels.push(
                     Label::secondary((), capture.node.byte_range())

--- a/src/rules/rule1d.rs
+++ b/src/rules/rule1d.rs
@@ -82,25 +82,35 @@ impl Rule for Rule1d {
             let diagnostic = match name {
                 "global.no_g_prefix" => {
                     let message = "Global variables must be prefixed with `g_'";
-                    Diagnostic::warning().with_code("I:D").with_message(message).with_labels(vec![
-                        Label::primary((), capture.node.byte_range())
-                            .with_message("Variable declared here"),
-                        Label::secondary((), capture.node.byte_range()).with_message(format!(
-                            "Perhaps you meant `g_{}'",
-                            capture.node.utf8_text(code).expect("Code is not valid UTF-8")
-                        )),
-                    ])
+                    Diagnostic::warning()
+                        .with_code("I:D")
+                        .with_message(message)
+                        .with_label(
+                            Label::primary((), capture.node.byte_range())
+                                .with_message("Variable declared here"),
+                        )
+                        .with_label(Label::secondary((), capture.node.byte_range()).with_message(
+                            format!(
+                                "Perhaps you meant `g_{}'",
+                                capture.node.utf8_text(code).expect("Code is not valid UTF-8")
+                            ),
+                        ))
                 }
                 "declaration.top_level" => {
                     let message =
                         "All top-level declarations must come before function definitions";
-                    Diagnostic::warning().with_code("I:D").with_message(message).with_labels(vec![
-                        Label::primary((), capture.node.byte_range())
-                            .with_message("Declaration occurs here"),
-                        // SAFETY: We will have returned if first_function_position is None.
-                        Label::secondary((), first_function_position.as_ref().unwrap().clone())
-                            .with_message("First function defined here"),
-                    ])
+                    Diagnostic::warning()
+                        .with_code("I:D")
+                        .with_message(message)
+                        .with_label(
+                            Label::primary((), capture.node.byte_range())
+                                .with_message("Declaration occurs here"),
+                        )
+                        .with_label(
+                            // SAFETY: We will have returned if first_function_position is None.
+                            Label::secondary((), first_function_position.as_ref().unwrap().clone())
+                                .with_message("First function defined here"),
+                        )
                 }
                 _ => unreachable!(),
             };

--- a/src/rules/rule2a.rs
+++ b/src/rules/rule2a.rs
@@ -61,7 +61,7 @@ impl Rule for Rule2a {
                 let diagnostic = Diagnostic::warning()
                     .with_code("II:A")
                     .with_message("Line length exceeds 80 columns.")
-                    .with_labels(vec![Label::primary((), (index + 80)..(index + line.len()))]);
+                    .with_label(Label::primary((), (index + 80)..(index + line.len())));
                 diagnostics.push(diagnostic);
             }
         }

--- a/src/rules/rule2b.rs
+++ b/src/rules/rule2b.rs
@@ -67,15 +67,14 @@ impl Rule for Rule2b {
                         MAX_PAGES_PER_FUNCTION,
                         MAX_PAGES_PER_FUNCTION * PAGE_SIZE
                     );
-                    let diagnostic = Diagnostic::warning()
-                        .with_code("II:B")
-                        .with_message(message)
-                        .with_labels(vec![Label::primary((), capture.node.byte_range())
-                            .with_message(format!(
+                    let diagnostic =
+                        Diagnostic::warning().with_code("II:B").with_message(message).with_label(
+                            Label::primary((), capture.node.byte_range()).with_message(format!(
                                 "Function `{}()' is {} lines long",
                                 function_definition_name(capture.node, code),
                                 length
-                            ))]);
+                            )),
+                        );
                     diagnostics.push(diagnostic);
                 }
             }
@@ -122,12 +121,10 @@ mod tests {
                     MAX_PAGES_PER_FUNCTION,
                     PAGE_SIZE * MAX_PAGES_PER_FUNCTION
                 ))
-                .with_labels(vec![
-                    Label::primary((), 0..(code.len() - 1)).with_message(format!(
-                        "Function `main()' is {} lines long",
-                        2 + MAX_PAGES_PER_FUNCTION * PAGE_SIZE
-                    ))
-                ])]
+                .with_label(Label::primary((), 0..(code.len() - 1)).with_message(format!(
+                    "Function `main()' is {} lines long",
+                    2 + MAX_PAGES_PER_FUNCTION * PAGE_SIZE
+                )))]
         );
     }
 }

--- a/src/rules/rule3a.rs
+++ b/src/rules/rule3a.rs
@@ -152,7 +152,7 @@ fn check_single_space_between(
         Diagnostic::warning()
             .with_code("III:A")
             .with_message(message.to_owned())
-            .with_labels(vec![Label::primary((), left.start_byte()..right.end_byte())]),
+            .with_label(Label::primary((), left.start_byte()..right.end_byte())),
     )
 }
 

--- a/src/rules/rule3b.rs
+++ b/src/rules/rule3b.rs
@@ -127,7 +127,7 @@ impl Rule for Rule3b {
                     Diagnostic::warning()
                         .with_code("III:B")
                         .with_message("Expected no space after unary operator")
-                        .with_labels(vec![Label::primary((), op.end_byte()..next.start_byte())]),
+                        .with_label(Label::primary((), op.end_byte()..next.start_byte())),
                 );
             }
         });
@@ -150,10 +150,7 @@ impl Rule for Rule3b {
                     Diagnostic::warning()
                         .with_code("III:B")
                         .with_message("Expected no space before array subscript")
-                        .with_labels(vec![Label::primary(
-                            (),
-                            prev.end_byte()..lbrack.start_byte(),
-                        )]),
+                        .with_label(Label::primary((), prev.end_byte()..lbrack.start_byte())),
                 );
             }
         });
@@ -210,7 +207,7 @@ fn check_binary_op_spacing(
         Diagnostic::warning()
             .with_code("III:B")
             .with_message(message)
-            .with_labels(vec![Label::primary((), range)]),
+            .with_label(Label::primary((), range)),
     )
 }
 
@@ -241,7 +238,7 @@ fn check_field_op_spacing(op: Node, left: Node, right: Node) -> Option<Diagnosti
         Diagnostic::warning()
             .with_code("III:B")
             .with_message(message)
-            .with_labels(vec![Label::primary((), range)]),
+            .with_label(Label::primary((), range)),
     )
 }
 

--- a/src/rules/rule3c.rs
+++ b/src/rules/rule3c.rs
@@ -82,10 +82,7 @@ impl Rule for Rule3c {
                     Diagnostic::warning()
                         .with_code("III:C")
                         .with_message("Expected one space after internal commas and semicolons")
-                        .with_labels(vec![Label::primary(
-                            (),
-                            delim.start_byte()..next.start_byte(),
-                        )]),
+                        .with_label(Label::primary((), delim.start_byte()..next.start_byte())),
                 );
             }
         });

--- a/src/rules/rule3d.rs
+++ b/src/rules/rule3d.rs
@@ -116,11 +116,13 @@ impl Rule for Rule3d {
                     Diagnostic::warning()
                         .with_code("III:D")
                         .with_message("Global preprocessor definitions must be placed at the top of the file, before all functions")
-                        .with_labels(vec![
-                            Label::primary((), print_range).with_message("Macro(s) defined here"),
+                        .with_label(
+                            Label::primary((), print_range).with_message("Macro(s) defined here")
+                        )
+                        .with_label(
                             // SAFETY: We've already checked that first_func.is_some_and(...).
                             Label::secondary((), first_func.unwrap().byte_range()).with_message("First function defined here")
-                        ])
+                        )
                 );
             }
         }
@@ -131,26 +133,19 @@ impl Rule for Rule3d {
                 Diagnostic::warning()
                     .with_code("III:D")
                     .with_message("All top-level #define statements must be grouped together")
-                    .with_labels(
-                        global_define_groups
-                            .into_iter()
-                            .enumerate()
-                            .map(|(i, group)| {
-                                let range = range_without_trailing_eol(
-                                    group.start_byte..group.end_byte,
-                                    code,
-                                );
-                                if i == 0 {
-                                    Label::secondary((), range).with_message(
-                                        "First group of #define statements found here",
-                                    )
-                                } else {
-                                    Label::primary((), range)
-                                        .with_message("More #define statements found here")
-                                }
-                            })
-                            .collect(),
-                    ),
+                    .with_labels_iter(global_define_groups.into_iter().enumerate().map(
+                        |(i, group)| {
+                            let range =
+                                range_without_trailing_eol(group.start_byte..group.end_byte, code);
+                            if i == 0 {
+                                Label::secondary((), range)
+                                    .with_message("First group of #define statements found here")
+                            } else {
+                                Label::primary((), range)
+                                    .with_message("More #define statements found here")
+                            }
+                        },
+                    )),
             );
         }
 
@@ -180,24 +175,20 @@ impl Rule for Rule3d {
                             "All #define statements in each function must be grouped together",
                         )
                         .with_notes(vec![format!("In function `{}()'", function_name)])
-                        .with_labels(
-                            groups_in_function
-                                .into_iter()
-                                .enumerate()
-                                .map(|(i, define_group)| {
-                                    let range = define_group.start_byte..define_group.end_byte;
-                                    let print_range = range_without_trailing_eol(range, code);
-                                    if i == 0 {
-                                        Label::secondary((), print_range).with_message(
-                                            "First group of #define statements found here",
-                                        )
-                                    } else {
-                                        Label::primary((), print_range)
-                                            .with_message("More #define statements found here")
-                                    }
-                                })
-                                .collect(),
-                        ),
+                        .with_labels_iter(groups_in_function.into_iter().enumerate().map(
+                            |(i, define_group)| {
+                                let range = define_group.start_byte..define_group.end_byte;
+                                let print_range = range_without_trailing_eol(range, code);
+                                if i == 0 {
+                                    Label::secondary((), print_range).with_message(
+                                        "First group of #define statements found here",
+                                    )
+                                } else {
+                                    Label::primary((), print_range)
+                                        .with_message("More #define statements found here")
+                                }
+                            },
+                        )),
                 );
             }
         }
@@ -253,11 +244,11 @@ impl Rule for Rule3d {
                         Diagnostic::warning()
                             .with_code("III:D")
                             .with_message("Expected blank line before #define statement(s)")
-                            .with_labels(vec![
-                                Label::primary((), print_range.clone()),
+                            .with_label(Label::primary((), print_range.clone()))
+                            .with_label(
                                 Label::secondary((), prev_line_range.unwrap())
                                     .with_message("Previous line is non-blank"),
-                            ]),
+                            ),
                     );
                 }
 
@@ -267,11 +258,11 @@ impl Rule for Rule3d {
                         Diagnostic::warning()
                             .with_code("III:D")
                             .with_message("Expected blank line after #define statement(s)")
-                            .with_labels(vec![
-                                Label::primary((), print_range),
+                            .with_label(Label::primary((), print_range))
+                            .with_label(
                                 Label::secondary((), next_line_range.unwrap())
                                     .with_message("Next line is non-blank"),
-                            ]),
+                            ),
                     );
                 }
 
@@ -281,13 +272,15 @@ impl Rule for Rule3d {
                         Diagnostic::warning()
                             .with_code("III:D")
                             .with_message("Expected blank lines surrounding #define statement(s)")
-                            .with_labels(vec![
-                                Label::primary((), print_range),
+                            .with_label(Label::primary((), print_range))
+                            .with_label(
                                 Label::secondary((), prev_line_range.unwrap())
                                     .with_message("Previous line is non-blank"),
+                            )
+                            .with_label(
                                 Label::secondary((), next_line_range.unwrap())
                                     .with_message("Next line is non-blank"),
-                            ]),
+                            ),
                     );
                 }
             }

--- a/src/rules/rule3e.rs
+++ b/src/rules/rule3e.rs
@@ -42,7 +42,7 @@ impl Rule for Rule3e {
                     Diagnostic::warning()
                         .with_code("III:E")
                         .with_message("Line contains trailing whitespace")
-                        .with_labels(vec![Label::primary((), start..end)]),
+                        .with_label(Label::primary((), start..end)),
                 );
             }
         }

--- a/src/rules/rule3f.rs
+++ b/src/rules/rule3f.rs
@@ -61,10 +61,7 @@ impl Rule for Rule3f {
                     Diagnostic::warning()
                         .with_code("III:F")
                         .with_message("Expected no space between function and parenthesis")
-                        .with_labels(vec![Label::primary(
-                            (),
-                            function.end_byte()..paren.start_byte(),
-                        )]),
+                        .with_label(Label::primary((), function.end_byte()..paren.start_byte())),
                 );
             }
         });


### PR DESCRIPTION
This version adds some nicer builder methods, specifically Diagnostic::with_label() and Diagnostic::with_labels_iter(), that let us avoid having to create extra temporary Vec's to hold labels when constructing diagnostics. This commit also changes existing code to use those new methods.