### PR TITLE
fix: usage of backticks in documentation comments

### DIFF
--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -37,7 +37,7 @@ pub struct QueryHelper<'src> {
 }
 
 impl<'src> QueryHelper<'src> {
-    /// Constructs a new [QueryHelper].
+    /// Constructs a new [`QueryHelper`].
     /// This function does not execute the query.
     ///
     /// # Arguments
@@ -85,7 +85,7 @@ impl<'src> QueryHelper<'src> {
     /// # Arguments
     ///
     /// - `handler`: Callback to execute for each capture.
-    ///   The arguments to the callback are the name of the capture and the [QueryCapture].
+    ///   The arguments to the callback are the name of the capture and the [`QueryCapture`].
     pub fn for_each_capture<'a, F>(&'a self, mut handler: F)
     where
         F: FnMut(&'a str, QueryCapture<'a>),
@@ -109,7 +109,7 @@ impl<'src> QueryHelper<'src> {
     /// # Arguments
     ///
     /// - `handler`: Callback to execute for each match.
-    ///   The argument to the callback is the [QueryMatch].
+    ///   The argument to the callback is the [`QueryMatch`].
     pub fn for_each_match<F>(&self, mut handler: F)
     where
         F: FnMut(&QueryMatch),
@@ -226,7 +226,7 @@ pub fn function_definition_name<'code>(node: Node, code: &'code [u8]) -> &'code 
 }
 
 /// Gets the number of columns by which this line is indented. Tab characters (U+0009 or `'\t'`)
-/// are counted as 8 columns. All other whitespace is sized using [unicode_width].
+/// are counted as 8 columns. All other whitespace is sized using [`unicode_width`].
 pub fn indent_width(line: &str) -> usize {
     line.chars()
         .take_while(|c| c.is_whitespace())
@@ -286,7 +286,7 @@ impl<'a> Iterator for LinesWithPosition<'a> {
 /// ```text
 /// 1..2, 2..3, 3..5, 6..7, 8..9, 9..10
 /// ```
-/// would be transformed by the [RangeCollapser] into:
+/// would be transformed by the [`RangeCollapser`] into:
 /// ```text
 /// 1..5, 6..7, 8..10
 /// ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ const LONG_ABOUT: &str = concat!("Westwood: ", crate_description!());
 #[derive(CliArgParser, Debug)]
 #[command(version, about = None, long_about = LONG_ABOUT)]
 struct CliOptions {
-    /// File to lint, or `-` for standard input
+    /// File to lint, or `-' for standard input
     file: FileOrStdin,
 
     #[arg(value_enum, short, long, default_value_t = OutputFormat::Pretty)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ const LONG_ABOUT: &str = concat!("Westwood: ", crate_description!());
 #[derive(CliArgParser, Debug)]
 #[command(version, about = None, long_about = LONG_ABOUT)]
 struct CliOptions {
-    /// File to lint, or `-' for standard input
+    /// File to lint, or `-` for standard input
     file: FileOrStdin,
 
     #[arg(value_enum, short, long, default_value_t = OutputFormat::Pretty)]
@@ -77,9 +77,9 @@ enum ColorMode {
     Always,
 }
 
-/// Lets us convert from our own [ColorMode] type into the [ColorChoice] type used by
-/// [codespan_reporting]. This is also where we check if stdout is a terminal, since
-/// [codespan_reporting] doesn't do that for us.
+/// Lets us convert from our own [`ColorMode`] type into the [`ColorChoice`] type used by
+/// [`codespan_reporting`]. This is also where we check if stdout is a terminal, since
+/// [`codespan_reporting`] doesn't do that for us.
 impl From<ColorMode> for ColorChoice {
     fn from(val: ColorMode) -> Self {
         match val {

--- a/src/rules/rule02a.rs
+++ b/src/rules/rule02a.rs
@@ -74,7 +74,7 @@ impl Rule for Rule02a {
 
 /// Returns the width of a line in columns.
 ///
-/// Returns the width according to the [unicode_width] module, but with tab characters (U+0009 or
+/// Returns the width according to the [`unicode_width`] module, but with tab characters (U+0009 or
 /// `'\t'`) treated as 8 columns wide.
 fn line_width(line: &str) -> usize {
     line.width() + line.chars().filter(|c| *c == '\t').count() * 7


### PR DESCRIPTION
Idiomatic Rust code's usage of backticks in documentation comments requires that names of terms with semantic meaning be surrounded by backticks and requires that backtick usage be balanced (per lint clippy::doc-markdown). This pull request ensures adherence to these standards across the codebase.