### PR TITLE
Enable clippy::pedantic warnings

### DIFF
--- a/src/helpers/testing.rs
+++ b/src/helpers/testing.rs
@@ -22,6 +22,9 @@ use super::QueryHelper;
 
 ///
 /// Tests a given query's captures on a certain input.
+///
+/// # Panics
+///
 /// Panics if the test fails.
 ///
 /// # Input format
@@ -128,14 +131,15 @@ pub fn test_captures(query: &str, input: &str) -> ExitCode {
             }
         }
     });
-    for (&(label, row, col), &expected_count) in test_specs.iter() {
+    for (&(label, row, col), &expected_count) in &test_specs {
         if expected_count > 0 {
-            eprintln!("Expected @{} at row {} column {}", label, row, col);
+            eprintln!("Expected @{label} at row {row} column {col}");
             failed = true;
         }
     }
-    match failed {
-        true => ExitCode::FAILURE,
-        false => ExitCode::SUCCESS,
+    if failed {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![warn(clippy::pedantic)]
+
 use std::io::stdout;
 use std::io::IsTerminal;
 use std::process::ExitCode;

--- a/src/rules/rule01a.rs
+++ b/src/rules/rule01a.rs
@@ -78,7 +78,7 @@ impl Rule for Rule01a {
                 _ => "Variable",
             };
             let diagnostic = Diagnostic::warning()
-                .with_message(format!("{} names must be in lower snake case.", nametype))
+                .with_message(format!("{nametype} names must be in lower snake case."))
                 .with_code("I:A")
                 .with_label(
                     Label::primary((), capture.node.byte_range())
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn rule01a() -> ExitCode {
-        let input = indoc! { /* c */ r#"
+        let input = indoc! { /* c */ r"
             int Name;
                 //!? name
             int *Name;
@@ -171,7 +171,7 @@ mod tests {
                   //!? name
             } MyType;
               //!? name
-        "#};
+        "};
         test_captures(super::QUERY_STR, input)
     }
 }

--- a/src/rules/rule01c.rs
+++ b/src/rules/rule01c.rs
@@ -85,7 +85,7 @@ impl Rule for Rule01c {
                 "constant.value.unwrapped_number" => (
                     "Numeric constant value must be wrapped in parentheses",
                     "Value defined here",
-                    Some(format!("({})", node_text)),
+                    Some(format!("({node_text})")),
                 ),
                 _ => unreachable!(),
             };
@@ -96,7 +96,7 @@ impl Rule for Rule01c {
             if let Some(fix) = fix {
                 diagnostic.labels.push(
                     Label::secondary((), capture.node.byte_range())
-                        .with_message(format!("Perhaps you meant `{}'", fix)),
+                        .with_message(format!("Perhaps you meant `{fix}'")),
                 );
             }
             diagnostics.push(diagnostic);

--- a/src/rules/rule01d.rs
+++ b/src/rules/rule01d.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn rule01d() -> ExitCode {
-        let input = indoc! { /* c */ r#"
+        let input = indoc! { /* c */ r"
             int an_int;
             //!? declaration.top_level
                 //!? global.no_g_prefix
@@ -172,7 +172,7 @@ mod tests {
                 int x;
             } another_global;
               //!? global.no_g_prefix
-        "#};
+        "};
         test_captures(QUERY_STR, input)
     }
 }

--- a/src/rules/rule02b.rs
+++ b/src/rules/rule02b.rs
@@ -42,9 +42,9 @@ const MAX_PAGES_PER_FUNCTION: usize = 2;
 /// Tree-sitter query for Rule I:D.
 const QUERY_STR: &str = indoc! {
     /* query */
-    r#"
+    r"
     (function_definition) @function
-    "#
+    "
 };
 
 /// # Rule II:B.

--- a/src/rules/rule03a.rs
+++ b/src/rules/rule03a.rs
@@ -173,7 +173,7 @@ mod tests {
     fn rule03a_captures() -> ExitCode {
         let input = indoc! {
             /* c */
-            r#"
+            r"
             int main() {
                 switch (x) {
                 //!? keyword
@@ -302,7 +302,7 @@ mod tests {
                  //!? keyword
                       //!? lparen
             }
-            "#
+            "
         };
         test_captures(QUERY_STR, input)
     }

--- a/src/rules/rule03b.rs
+++ b/src/rules/rule03b.rs
@@ -39,12 +39,12 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 /// Tree-sitter query to capture binary expressions/operators.
 const QUERY_STR_BINARY: &str = indoc! {
     /* query */
-    r#"
+    r"
     (binary_expression
         left: _ @prev
         operator: _ @binary-operator
         right: _ @next)
-    "#
+    "
 };
 
 /// Tree-sitter query to capture unary expressions/operators.
@@ -81,12 +81,12 @@ const QUERY_STR_ARRAY: &str = indoc! {
 /// Tree-sitter query to capture field expressions/operators.
 const QUERY_STR_FIELD: &str = indoc! {
     /* query */
-    r#"
+    r"
     (field_expression
         argument: _ @prev
         operator: _ @field-operator
         field: _ @next)
-    "#
+    "
 };
 
 /// # Rule III:B.
@@ -265,7 +265,7 @@ mod tests {
     fn binary_op_captures() -> ExitCode {
         let input = indoc! {
             /* c */
-            r#"
+            r"
             int main() {
                 1 + 2;
                 //!? prev
@@ -297,7 +297,7 @@ mod tests {
                     //!? next
                 }
             }
-            "#
+            "
         }
         .replace("binop", "binary-operator");
         test_captures(QUERY_STR_BINARY, &input)
@@ -333,7 +333,7 @@ mod tests {
     #[test]
     fn field_op_captures() -> ExitCode {
         let input = indoc! {
-            /* c */ r#"
+            /* c */ r"
             int main(int argc) {
                 a->b;
                 //!? prev
@@ -354,7 +354,7 @@ mod tests {
                       //!? field-operator
                        //!? next
             }
-            "#
+            "
         };
         test_captures(QUERY_STR_FIELD, input)
     }

--- a/src/rules/rule03d.rs
+++ b/src/rules/rule03d.rs
@@ -108,7 +108,7 @@ impl Rule for Rule03d {
         // Check that global #define statements come before function definitions
         let global_define_groups: Vec<TSRange> =
             RangeCollapser::from(global_definitions.into_iter().map(|def| def.range())).collect();
-        for group in global_define_groups.iter() {
+        for group in &global_define_groups {
             if first_func.is_some_and(|func| func.end_byte() < group.start_byte) {
                 let print_range =
                     range_without_trailing_eol(group.start_byte..group.end_byte, code);
@@ -209,12 +209,11 @@ impl Rule for Rule03d {
             let has_blank_before =
                 define.start_point.row == 0 || lines[define.start_point.row - 1].0.is_empty();
             // Byte range of the previous line so we can label it
-            let prev_line_range: Option<Range<usize>> = match has_blank_before {
-                true => None,
-                false => {
-                    let (prev_line, prev_line_start) = lines[define.start_point.row - 1];
-                    Some(prev_line_start..(prev_line_start + prev_line.len()))
-                }
+            let prev_line_range: Option<Range<usize>> = if has_blank_before {
+                None
+            } else {
+                let (prev_line, prev_line_start) = lines[define.start_point.row - 1];
+                Some(prev_line_start..(prev_line_start + prev_line.len()))
             };
 
             // If the #define does not end at the start of a line, take the next line
@@ -225,12 +224,11 @@ impl Rule for Rule03d {
                 };
             let has_blank_after = lines.get(end_line).is_none_or(|(line, _pos)| line.is_empty());
             // Byte range of the following line so we can label it
-            let next_line_range: Option<Range<usize>> = match has_blank_after {
-                true => None,
-                false => {
-                    let (next_line, next_line_start) = lines[end_line];
-                    Some(next_line_start..(next_line_start + next_line.len()))
-                }
+            let next_line_range: Option<Range<usize>> = if has_blank_after {
+                None
+            } else {
+                let (next_line, next_line_start) = lines[end_line];
+                Some(next_line_start..(next_line_start + next_line.len()))
             };
 
             // Produce diagnostic
@@ -318,12 +316,12 @@ mod tests {
     #[test]
     fn grouping() {
         let code = indoc! {
-            /* c */ r#"
+            /* c */ r"
             // comment
             #define A
             #define B
             // comment
-            "#
+            "
         };
         let mut parser = Parser::new();
         parser.set_language(&tree_sitter_c::LANGUAGE.into()).unwrap();

--- a/src/rules/rule11a.rs
+++ b/src/rules/rule11a.rs
@@ -35,6 +35,7 @@ impl Rule11a {
     ///
     /// `max_diagnostics` specifies the maximum number of diagnostics to output. If more than this
     /// are produced, a note is displayed on the last one and the rest are hidden.
+    #[must_use]
     pub fn new(max_diagnostics: Option<usize>) -> Self {
         Self { max_diagnostics }
     }
@@ -73,6 +74,7 @@ impl Rule for Rule11a {
                     .filter(|(_pos, c)| *c == '\t')
                     .map(|(pos, _c)| pos)
                     .map(|pos| {
+                        #[allow(clippy::range_plus_one)]
                         Label::primary((), (start_pos + pos)..(start_pos + pos + 1))
                             .with_message("Tab character found here")
                     })
@@ -95,8 +97,7 @@ impl Rule for Rule11a {
                 let remaining = diagnostics.len() - max;
                 diagnostics.truncate(max);
                 diagnostics.last_mut().unwrap().notes.push(format!(
-                    "{} more lines contain tabs, but those warnings are suppressed to avoid noise.",
-                    remaining
+                    "{remaining} more lines contain tabs, but those warnings are suppressed to avoid noise."
                 ));
             }
         }

--- a/src/rules/rule11b.rs
+++ b/src/rules/rule11b.rs
@@ -37,6 +37,7 @@ impl Rule11b {
     ///
     /// `max_diagnostics` specifies the maximum number of diagnostics to output. If more than this
     /// are produced, a note is displayed on the last one and the rest are hidden.
+    #[must_use]
     pub fn new(max_diagnostics: Option<NonZeroUsize>) -> Self {
         Self { max_diagnostics }
     }
@@ -67,7 +68,10 @@ impl Rule for Rule11b {
                 Diagnostic::warning()
                     .with_code("XI:B")
                     .with_message("Line contains DOS-style ending")
-                    .with_label(Label::primary((), cr_pos..(cr_pos + 1)))
+                    .with_label(
+                        #[allow(clippy::range_plus_one)]
+                        Label::primary((), cr_pos..(cr_pos + 1)),
+                    )
                     .with_note("Use the `fileformat' option in Vim to fix this"),
             );
 

--- a/src/rules/rule11e.rs
+++ b/src/rules/rule11e.rs
@@ -27,9 +27,9 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 /// Tree-sitter query for Rule XI:E.
 const QUERY_STR: &str = indoc! {
     /* query */
-    r#"
+    r"
     (goto_statement) @goto
-    "#
+    "
 };
 
 /// # Rule XI:E.
@@ -67,14 +67,14 @@ mod tests {
     #[test]
     fn rule11e_captures() -> ExitCode {
         let input = indoc! {
-            /* c */ r#"
+            /* c */ r"
             int main() {
                 goto label;
                 //!? goto
                 label:
                 return 0;
             }
-            "#
+            "
         };
         test_captures(QUERY_STR, input)
     }

--- a/src/rules/rule12a.rs
+++ b/src/rules/rule12a.rs
@@ -151,17 +151,17 @@ mod tests {
     fn is_function_declaration() {
         // Here, every other declaration starting with the first must be a function declaration
         let function_declarations = indoc! {
-            /* c */ r#"
+            /* c */ r"
             int main(void);
             char *get_string(void);
             void nested_declaration(void (*inner)(void));
-            "#
+            "
         };
         let non_function_declarations = indoc! {
-            /* c */ r#"
+            /* c */ r"
             int not_a_function;
             char *string;
-            "#
+            "
         };
         let mut parser = Parser::new();
         parser.set_language(&tree_sitter_c::LANGUAGE.into()).unwrap();
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn captures() -> ExitCode {
         let input = indoc! {
-            /* c */ r#"
+            /* c */ r"
             int var2, *var2, var3[10];
             //!? declaration first-child
 
@@ -226,7 +226,7 @@ mod tests {
                 void another(void (*inner)(void));
                 //!? declaration
             }
-            "#
+            "
         };
         test_captures(QUERY_STR, input)
     }


### PR DESCRIPTION
Enables more pedantic warnings from Clippy and fixes the subsequent warnings produced on the existing codebase.

To do:
- [x] See if there's a happy middle ground in between completely enabling and disabling the `clippy::missing_panics_doc` warning. It would be nice to exempt certain `.unwrap()` calls from triggering the warning, while still keeping it for other `.unwrap()` calls or explicit `panic!()` uses.