### PR TITLE
chore(crashlog): Replace getrandom dependency with fastrand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
-
-[[package]]
 name = "cc"
 version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,12 +75,6 @@ checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -168,7 +156,7 @@ name = "crashlog"
 version = "0.1.3"
 dependencies = [
  "chrono",
- "getrandom",
+ "fastrand",
  "os_info",
  "pretty_assertions",
 ]
@@ -186,16 +174,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "getrandom"
-version = "0.3.3"
+name = "fastrand"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi",
-]
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "hashbrown"
@@ -236,12 +218,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "libc"
-version = "0.2.172"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "log"
@@ -307,12 +283,6 @@ checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "regex"
@@ -489,15 +459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
-
-[[package]]
 name = "westwood"
 version = "0.0.0"
 dependencies = [
@@ -603,15 +564,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
 
 [[package]]
 name = "yansi"

--- a/crashlog/Cargo.toml
+++ b/crashlog/Cargo.toml
@@ -16,7 +16,7 @@ rust-version.workspace = true
 
 [dependencies]
 chrono = { version = "0.4.41", features = ["now"], default-features = false }
-getrandom = "0.3.3"
+fastrand = "2.3.0"
 os_info = { version = "3.11.0", default-features = false }
 
 [dev-dependencies]

--- a/crashlog/src/bin/crashlog_test_subject.rs
+++ b/crashlog/src/bin/crashlog_test_subject.rs
@@ -13,6 +13,11 @@ pub fn main() {
         match arg.as_str() {
             "--custom" => opts.custom_message = true,
             "--replace" => opts.replace = true,
+            arg if arg.starts_with("--seed=") => {
+                let seed_str = arg.strip_prefix("--seed=").unwrap();
+                let seed = seed_str.parse::<u64>().unwrap();
+                fastrand::seed(seed);
+            }
             _ => (),
         }
     }

--- a/crashlog/src/lib.rs
+++ b/crashlog/src/lib.rs
@@ -147,7 +147,7 @@ pub fn try_generate_report(
 ) -> Option<PathBuf> {
     // Construct filename
     let mut path = std::env::temp_dir();
-    path.push(format!("{:08x}.txt", getrandom::u64().ok()?));
+    path.push(format!("{:08x}.txt", fastrand::u64(0..=u64::MAX)));
 
     // Open file and create buffer
     let file = File::create(&path).ok()?;


### PR DESCRIPTION
Since we don't need secure RNG, we can use the lighter `fastrand` crate, which has fewer dependencies. It also allows us to make the integration tests deterministic, as we can seed the PRNG to control the path of the crash log file.