### PR TITLE
refactor: construct reusable source code information only once

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use codespan_reporting::{
     },
 };
 use crashlog::cargo_metadata;
+use rules::api::SourceInfo;
 use tree_sitter::{Parser, Tree};
 
 pub mod helpers;
@@ -145,8 +146,9 @@ fn main() -> ExitCode {
 
     // Do checks
     let rules: Vec<Box<dyn Rule>> = crate::rules::get_rules();
+    let source = SourceInfo::new(&code);
     for rule in rules {
-        let diagnostics = rule.check(&tree, &code);
+        let diagnostics = rule.check(&source);
         for diagnostic in diagnostics {
             match cli.format {
                 OutputFormat::Pretty => {

--- a/src/rules/rule01a.rs
+++ b/src/rules/rule01a.rs
@@ -32,9 +32,10 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::Tree;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
+
+use crate::rules::api::SourceInfo;
 
 const QUERY_STR: &str = indoc! { /* query */ r#"
     (
@@ -65,7 +66,7 @@ const QUERY_STR: &str = indoc! { /* query */ r#"
 pub struct Rule01a {}
 
 impl Rule for Rule01a {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut diagnostics = Vec::new();
         helper.for_each_capture(|_label, capture| {

--- a/src/rules/rule01b.rs
+++ b/src/rules/rule01b.rs
@@ -36,9 +36,8 @@
 //! - Make this rule produce a table of all declared identifiers at the end of parsing.
 
 use codespan_reporting::diagnostic::Diagnostic;
-use tree_sitter::Tree;
 
-use crate::rules::api::Rule;
+use crate::rules::api::{Rule, SourceInfo};
 
 /// # Rule I:B.
 ///
@@ -46,7 +45,7 @@ use crate::rules::api::Rule;
 pub struct Rule01b {}
 
 impl Rule for Rule01b {
-    fn check(&self, _tree: &Tree, _code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, _: &SourceInfo) -> Vec<Diagnostic<()>> {
         Vec::with_capacity(0)
     }
 }

--- a/src/rules/rule01c.rs
+++ b/src/rules/rule01c.rs
@@ -40,9 +40,11 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::{QueryCapture, Tree};
+use tree_sitter::QueryCapture;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
+
+use crate::rules::api::SourceInfo;
 
 /// Tree-sitter query for Rule I:C.
 const QUERY_STR: &str = indoc! { /* query */ r#"
@@ -66,7 +68,7 @@ const QUERY_STR: &str = indoc! { /* query */ r#"
 pub struct Rule01c {}
 
 impl Rule for Rule01c {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut diagnostics = Vec::new();
         helper.for_each_capture(|name: &str, capture: QueryCapture| {

--- a/src/rules/rule01d.rs
+++ b/src/rules/rule01d.rs
@@ -32,9 +32,12 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::{QueryCapture, Tree};
+use tree_sitter::QueryCapture;
 
-use crate::{helpers::QueryHelper, rules::api::Rule};
+use crate::{
+    helpers::QueryHelper,
+    rules::api::{Rule, SourceInfo},
+};
 
 /// Tree-sitter query for Rule I:D.
 const QUERY_STR: &str = indoc! {
@@ -64,7 +67,7 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule01d {}
 
 impl Rule for Rule01d {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut first_function_position = None;
         let mut diagnostics = Vec::new();

--- a/src/rules/rule03a.rs
+++ b/src/rules/rule03a.rs
@@ -26,9 +26,11 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::{Node, Tree};
+use tree_sitter::Node;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
+
+use crate::rules::api::SourceInfo;
 
 /// Tree-sitter query for Rule III:A.
 const QUERY_STR: &str = indoc! {
@@ -88,7 +90,7 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule03a {}
 
 impl Rule for Rule03a {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 
         // Part 1: Space between parentheses and braces

--- a/src/rules/rule03a.rs
+++ b/src/rules/rule03a.rs
@@ -121,7 +121,8 @@ impl Rule for Rule03a {
             // Check spacing between keyword and (
             let keyword = helper.expect_node_for_capture_index(qmatch, keyword_capture_i);
             let lparen = helper.expect_node_for_capture_index(qmatch, lparen_capture_i);
-            let message = format!("Expected a single space after `{code}'");
+            let message =
+                format!("Expected a single space after `{}'", &code[keyword.byte_range()]);
             if let Some(diagnostic) = check_single_space_between(keyword, lparen, code, &message) {
                 diagnostics.push(diagnostic);
             }

--- a/src/rules/rule03b.rs
+++ b/src/rules/rule03b.rs
@@ -32,9 +32,11 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::{Node, Tree};
+use tree_sitter::Node;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
+
+use crate::rules::api::SourceInfo;
 
 /// Tree-sitter query to capture binary expressions/operators.
 const QUERY_STR_BINARY: &str = indoc! {
@@ -95,7 +97,7 @@ const QUERY_STR_FIELD: &str = indoc! {
 pub struct Rule03b {}
 
 impl Rule for Rule03b {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 
         // Binary expressions

--- a/src/rules/rule03c.rs
+++ b/src/rules/rule03c.rs
@@ -24,9 +24,11 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::{Node, Tree};
+use tree_sitter::Node;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
+
+use crate::rules::api::SourceInfo;
 
 /// Tree-sitter query for Rule III:C.
 const QUERY_STR: &str = indoc! {
@@ -63,7 +65,7 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule03c {}
 
 impl Rule for Rule03c {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let delim_capture_i = helper.expect_index_for_capture("delim");

--- a/src/rules/rule03e.rs
+++ b/src/rules/rule03e.rs
@@ -19,9 +19,10 @@
 //! ```
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
-use tree_sitter::Tree;
 
-use crate::{helpers::LinesWithPosition, rules::api::Rule};
+use crate::rules::api::Rule;
+
+use crate::rules::api::SourceInfo;
 
 /// # Rule III:E.
 ///
@@ -29,9 +30,9 @@ use crate::{helpers::LinesWithPosition, rules::api::Rule};
 pub struct Rule03e {}
 
 impl Rule for Rule03e {
-    fn check(&self, _tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { lines, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
-        for (line, index) in LinesWithPosition::from(code) {
+        for (line, index) in lines {
             let trimmed_line = line.trim_end();
             if trimmed_line.len() != line.len() {
                 // Start/end of trailing whitespace
@@ -51,9 +52,7 @@ impl Rule for Rule03e {
 
 #[cfg(test)]
 mod tests {
-    use tree_sitter::Parser;
-
-    use crate::rules::api::Rule;
+    use crate::rules::api::{Rule, SourceInfo};
 
     use super::Rule03e;
 
@@ -62,11 +61,9 @@ mod tests {
     #[test]
     fn rule03e() {
         let code = "int main() { \n  return 0;\t\n}\n";
-        let mut parser = Parser::new();
-        parser.set_language(&tree_sitter_c::LANGUAGE.into()).unwrap();
-        let tree = parser.parse(code, None).unwrap();
+        let source = SourceInfo::new(code);
         let rule = Rule03e {};
-        let diagnostics = rule.check(&tree, code);
+        let diagnostics = rule.check(&source);
         assert_eq!(2, diagnostics.len());
     }
 }

--- a/src/rules/rule03f.rs
+++ b/src/rules/rule03f.rs
@@ -21,9 +21,10 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::Tree;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
+
+use crate::rules::api::SourceInfo;
 
 /// Tree-sitter query for Rule III:F.
 const QUERY_STR: &str = indoc! {
@@ -47,7 +48,7 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule03f {}
 
 impl Rule for Rule03f {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let function_capture_i = helper.expect_index_for_capture("function");

--- a/src/rules/rule11b.rs
+++ b/src/rules/rule11b.rs
@@ -21,9 +21,10 @@
 use std::num::NonZeroUsize;
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
-use tree_sitter::Tree;
 
 use crate::rules::api::Rule;
+
+use crate::rules::api::SourceInfo;
 
 /// # Rule XI:B.
 ///
@@ -44,7 +45,7 @@ impl Rule11b {
 }
 
 impl Rule for Rule11b {
-    fn check(&self, _tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 
         // Search for DOS-style newlines
@@ -95,16 +96,8 @@ mod tests {
     use std::num::NonZeroUsize;
 
     use pretty_assertions::{assert_eq, assert_str_eq};
-    use tree_sitter::{Parser, Tree};
 
-    use crate::rules::api::Rule;
-
-    /// Returns a [Tree] for the given C code.
-    fn parse(code: &str) -> Tree {
-        let mut parser = Parser::new();
-        parser.set_language(&tree_sitter_c::LANGUAGE.into()).unwrap();
-        parser.parse(code.as_bytes(), None).unwrap()
-    }
+    use crate::rules::api::{Rule, SourceInfo};
 
     /// Tests the diagnostics produced when a file has CRLF endings.
     /// Specifically checks for:
@@ -115,7 +108,7 @@ mod tests {
     fn has_crlf() {
         let code = "int main() {\r\n  return 0;\r\n}\r\n";
         let rule = super::Rule11b::new(None);
-        let diagnostics = rule.check(&parse(code), code);
+        let diagnostics = rule.check(&SourceInfo::new(code));
         assert_eq!(3, diagnostics.len());
         let cr_positions: Vec<usize> = code
             .char_indices()
@@ -133,7 +126,7 @@ mod tests {
     fn no_crlf() {
         let code = "int main() {\n  return 0;\n}\n";
         let rule = super::Rule11b::new(None);
-        let diagnostics = rule.check(&parse(code), code);
+        let diagnostics = rule.check(&SourceInfo::new(code));
         assert!(diagnostics.is_empty());
     }
 
@@ -142,7 +135,7 @@ mod tests {
     fn limit() {
         let code = "int main() {\r\n  return 0;\r\n}\r\n";
         let rule = super::Rule11b::new(Some(NonZeroUsize::new(1).unwrap()));
-        let diagnostics = rule.check(&parse(code), code);
+        let diagnostics = rule.check(&SourceInfo::new(code));
         assert_eq!(1, diagnostics.len());
         assert_eq!(2, diagnostics[0].notes.len());
         // First note is Vim tip; second is remaining warnings.

--- a/src/rules/rule11e.rs
+++ b/src/rules/rule11e.rs
@@ -20,9 +20,10 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::Tree;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
+
+use crate::rules::api::SourceInfo;
 
 /// Tree-sitter query for Rule XI:E.
 const QUERY_STR: &str = indoc! {
@@ -38,7 +39,7 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule11e {}
 
 impl Rule for Rule11e {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         helper.for_each_capture(|label, capture| {

--- a/src/rules/rule12a.rs
+++ b/src/rules/rule12a.rs
@@ -31,9 +31,11 @@
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
-use tree_sitter::{Node, Tree};
+use tree_sitter::Node;
 
 use crate::{helpers::QueryHelper, rules::api::Rule};
+
+use crate::rules::api::SourceInfo;
 
 /// # Rule XII:A.
 ///
@@ -62,7 +64,7 @@ const QUERY_STR: &str = indoc! {
 };
 
 impl Rule for Rule12a {
-    fn check(&self, tree: &Tree, code: &str) -> Vec<Diagnostic<()>> {
+    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 
         let helper = QueryHelper::new(QUERY_STR, tree, code);


### PR DESCRIPTION
Closes #11.