### PR TITLE
refactor: use custom diagnostic types

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,0 +1,258 @@
+//! Diagnostic types
+
+use std::{borrow::Cow, ops::Range};
+
+use tree_sitter::Node;
+
+use crate::{
+    helpers::line_width,
+    rules::api::{RuleDescription, SourceInfo},
+};
+
+/// Represents a diagnostic message for a code standard violation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic<'a> {
+    /// Description of the code standard rule that was violated.
+    pub rule: &'static RuleDescription,
+
+    /// Message describing the violation.
+    pub message: Cow<'a, str>,
+
+    /// Locations of code that violated the rule.
+    pub violations: Vec<Span<'a>>,
+
+    /// Locations of code that are relevant to the violation but are not violations themselves.
+    pub references: Vec<Span<'a>>,
+
+    /// Optional suggestion for fixing the violation.
+    pub suggestion: Option<String>,
+}
+
+impl<'a> Diagnostic<'a> {
+    /// Creates a new `Diagnostic` with the given rule, message, and spans.
+    pub fn new<M>(rule: &'static RuleDescription, message: M) -> Self
+    where
+        M: Into<Cow<'a, str>>,
+    {
+        Self {
+            rule,
+            message: message.into(),
+            violations: Vec::new(),
+            references: Vec::new(),
+            suggestion: None,
+        }
+    }
+
+    /// Adds a violation span and returns the modified diagnostic.
+    pub fn with_violation(mut self, span: Span<'a>) -> Self {
+        self.violations.push(span);
+        self
+    }
+
+    /// Adds a violation span constructed by calling [`Span::new()`] with the given arguments.
+    /// Returns the modified diagnostic.
+    pub fn with_violation_parts<L>(
+        mut self,
+        filename: &'a str,
+        range: SourceRange,
+        label: L,
+    ) -> Self
+    where
+        L: Into<Cow<'a, str>>,
+    {
+        self.violations.push(Span::new(filename, range, label));
+        self
+    }
+
+    /// Replaces the existing violations with the provided list and returns the modified
+    /// diagnostic.
+    pub fn with_violations(mut self, violations: Vec<Span<'a>>) -> Self {
+        self.violations = violations;
+        self
+    }
+
+    /// Adds a reference span and returns the modified diagnostic.
+    pub fn with_reference(mut self, span: Span<'a>) -> Self {
+        self.references.push(span);
+        self
+    }
+
+    /// Adds a reference span constructed by calling [`Span::new()`] with the given arguments.
+    /// Returns the modified diagnostic.
+    pub fn with_reference_parts<L>(
+        mut self,
+        filename: &'a str,
+        range: SourceRange,
+        label: L,
+    ) -> Self
+    where
+        L: Into<Cow<'a, str>>,
+    {
+        self.references.push(Span::new(filename, range, label));
+        self
+    }
+
+    /// Replaces the existing references with the provided list and returns the modified
+    /// diagnostic.
+    pub fn with_references(mut self, references: Vec<Span<'a>>) -> Self {
+        self.references = references;
+        self
+    }
+
+    /// Adds a suggestion and returns the modified diagnostic.
+    pub fn with_suggestion(mut self, suggestion: String) -> Self {
+        self.suggestion = Some(suggestion);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Span<'a> {
+    /// Name of the source file.
+    pub filename: &'a str,
+
+    /// Range of the source code.
+    pub range: SourceRange,
+
+    /// Label for the span.
+    pub label: Cow<'a, str>,
+}
+
+impl<'a> Span<'a> {
+    /// Creates a new `Span` with the given filename, range, and label.
+    pub fn new<L>(filename: &'a str, range: SourceRange, label: L) -> Self
+    where
+        L: Into<Cow<'a, str>>,
+    {
+        Self {
+            filename,
+            range,
+            label: label.into(),
+        }
+    }
+}
+
+/// Represents a range of source code, as both a byte range and line/column positions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceRange {
+    /// Range of bytes in the source code.
+    pub bytes: Range<usize>,
+    /// Start position (inclusive) in the source code as 0-indexed (row, column).
+    pub start_pos: (usize, usize),
+    /// End position (exclusive) in the source code as 0-indexed (row, column).
+    pub end_pos: (usize, usize),
+}
+
+impl From<Node<'_>> for SourceRange {
+    /// Creates a [`SourceRange`] from a [`Node`]'s range.
+    fn from(node: Node<'_>) -> Self {
+        Self {
+            bytes: node.start_byte()..node.end_byte(),
+            start_pos: (node.start_position().row, node.start_position().column),
+            end_pos: (node.end_position().row, node.end_position().column),
+        }
+    }
+}
+
+impl SourceRange {
+    /// Creates a new [`SourceRange`] that starts at the start of the first node and ends at the
+    /// start of the second node.
+    pub fn start_to_start(left: Node<'_>, right: Node<'_>) -> Self {
+        Self {
+            bytes: left.start_byte()..right.start_byte(),
+            start_pos: (left.start_position().row, left.start_position().column),
+            end_pos: (right.start_position().row, right.start_position().column),
+        }
+    }
+
+    // Generate the function above but for end_to_end, start_to_end, and end_to_start
+    /// Creates a new [`SourceRange`] that starts at the end of the first node and ends at the
+    /// end of the second node.
+    pub fn end_to_end(left: Node<'_>, right: Node<'_>) -> Self {
+        Self {
+            bytes: left.end_byte()..right.end_byte(),
+            start_pos: (left.end_position().row, left.end_position().column),
+            end_pos: (right.end_position().row, right.end_position().column),
+        }
+    }
+
+    /// Creates a new [`SourceRange`] that starts at the start of the first node and ends at the
+    /// end of the second node.
+    pub fn start_to_end(left: Node<'_>, right: Node<'_>) -> Self {
+        Self {
+            bytes: left.start_byte()..right.end_byte(),
+            start_pos: (left.start_position().row, left.start_position().column),
+            end_pos: (right.end_position().row, right.end_position().column),
+        }
+    }
+
+    /// Creates a new [`SourceRange`] that starts at the end of the first node and ends at the
+    /// start of the second node.
+    pub fn end_to_start(left: Node<'_>, right: Node<'_>) -> Self {
+        Self {
+            bytes: left.end_byte()..right.start_byte(),
+            start_pos: (left.end_position().row, left.end_position().column),
+            end_pos: (right.start_position().row, right.start_position().column),
+        }
+    }
+
+    /// Creates a [`SourceRange`] from just a byte range, using the provided `SourceInfo` to determine
+    /// the start and end positions.
+    pub fn from_byte_range(bytes: Range<usize>, source: &SourceInfo) -> Self {
+        // Find start line
+        let start_line_i = source
+            .lines
+            .partition_point(|&(_, pos)| pos <= bytes.start)
+            .checked_sub(1)
+            .unwrap();
+        let start_line_pos = source.lines[start_line_i].1;
+        // Select the part of the line that is within the range to calculate the width
+        let start_line_selected_part =
+            &source.lines[start_line_i].0[..(bytes.start - start_line_pos)];
+
+        // Find end line
+        let end_line_i = source
+            .lines
+            .partition_point(|&(_, pos)| pos <= bytes.end)
+            .checked_sub(1)
+            .unwrap();
+        let end_line_pos = source.lines[end_line_i].1;
+        // Select the part of the line that is within the range to calculate the width
+        let end_line_selected_part = &source.lines[end_line_i].0[..(bytes.end - end_line_pos)];
+
+        Self {
+            bytes,
+            start_pos: (start_line_i, line_width(start_line_selected_part)),
+            end_pos: (end_line_i, line_width(end_line_selected_part)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::{SourceInfo, SourceRange};
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn source_range_with_pos_from() {
+        let code = indoc! { /* c */ r#"
+            int main() {
+                return 0;
+            } /* main() */
+        "# };
+        let source = SourceInfo::new("test.c", code);
+        let tests = vec![
+            (0..3, (0, 0), (0, 3)),   // "int"
+            (0..12, (0, 0), (0, 12)), // first line without newline
+            (0..13, (0, 0), (1, 0)),  // first line with newline
+        ];
+        for (byte_range, expected_start, expected_end) in tests.into_iter() {
+            let source_range = SourceRange::from_byte_range(byte_range, &source);
+            assert_eq!(source_range.start_pos, expected_start);
+            assert_eq!(source_range.end_pos, expected_end);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ use crashlog::cargo_metadata;
 use rules::api::SourceInfo;
 use tree_sitter::{Parser, Tree};
 
+pub mod diagnostic;
 pub mod helpers;
 pub mod rules;
 
@@ -156,7 +157,7 @@ fn main() -> ExitCode {
     let files = SimpleFile::new(filename, &code);
 
     // Do checks
-    let source = SourceInfo::new(&code);
+    let source = SourceInfo::new(&filename, &code);
     let mut diagnostics: Vec<_> = crate::rules::get_rules()
         .into_iter()
         .flat_map(|rule| rule.check(&source))

--- a/src/rules/rule01a.rs
+++ b/src/rules/rule01a.rs
@@ -37,6 +37,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 const QUERY_STR: &str = indoc! { /* query */ r#"
     (
         [
@@ -66,6 +68,16 @@ const QUERY_STR: &str = indoc! { /* query */ r#"
 pub struct Rule01a {}
 
 impl Rule for Rule01a {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 1,
+            letter: 'A',
+            code: "I:A",
+            name: "LowerSnakeCaseNames",
+            description: "names must be in lower snake case",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut diagnostics = Vec::new();

--- a/src/rules/rule01b.rs
+++ b/src/rules/rule01b.rs
@@ -35,9 +35,10 @@
 //!
 //! - Make this rule produce a table of all declared identifiers at the end of parsing.
 
-use codespan_reporting::diagnostic::Diagnostic;
-
-use crate::rules::api::{Rule, RuleDescription, SourceInfo};
+use crate::{
+    diagnostic::Diagnostic,
+    rules::api::{Rule, RuleDescription, SourceInfo},
+};
 
 /// # Rule I:B.
 ///
@@ -55,7 +56,7 @@ impl Rule for Rule01b {
         }
     }
 
-    fn check(&self, _: &SourceInfo) -> Vec<Diagnostic<()>> {
-        Vec::with_capacity(0)
+    fn check<'a>(&self, _: &'a SourceInfo) -> Vec<Diagnostic<'a>> {
+        Vec::new()
     }
 }

--- a/src/rules/rule01b.rs
+++ b/src/rules/rule01b.rs
@@ -37,7 +37,7 @@
 
 use codespan_reporting::diagnostic::Diagnostic;
 
-use crate::rules::api::{Rule, SourceInfo};
+use crate::rules::api::{Rule, RuleDescription, SourceInfo};
 
 /// # Rule I:B.
 ///
@@ -45,6 +45,16 @@ use crate::rules::api::{Rule, SourceInfo};
 pub struct Rule01b {}
 
 impl Rule for Rule01b {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 1,
+            letter: 'B',
+            code: "I:B",
+            name: "MeaningfulNames",
+            description: "variable names must be descriptive and meaningful",
+        }
+    }
+
     fn check(&self, _: &SourceInfo) -> Vec<Diagnostic<()>> {
         Vec::with_capacity(0)
     }

--- a/src/rules/rule01c.rs
+++ b/src/rules/rule01c.rs
@@ -38,10 +38,10 @@
 //!   `#define ABC 1 + 2` doesn't. Fixing this will require re-parsing all `preproc_arg` nodes, as
 //!   the current [tree-sitter-c][tree_sitter_c] grammar treats them as literal text.
 
-use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
 use tree_sitter::QueryCapture;
 
+use crate::diagnostic::{Diagnostic, Span};
 use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
@@ -80,7 +80,15 @@ impl Rule for Rule01c {
         }
     }
 
-    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
+    fn check<'a>(
+        &self,
+        SourceInfo {
+            filename,
+            tree,
+            code,
+            ..
+        }: &'a SourceInfo,
+    ) -> Vec<Diagnostic<'a>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut diagnostics = Vec::new();
         helper.for_each_capture(|name: &str, capture: QueryCapture| {
@@ -103,15 +111,10 @@ impl Rule for Rule01c {
                 ),
                 _ => unreachable!(),
             };
-            let mut diagnostic = Diagnostic::warning()
-                .with_code("I:C")
-                .with_message(message)
-                .with_label(Label::primary((), capture.node.byte_range()).with_message(label));
+            let mut diagnostic =
+                self.report(message).with_violation_parts(filename, capture.node.into(), label);
             if let Some(fix) = fix {
-                diagnostic.labels.push(
-                    Label::secondary((), capture.node.byte_range())
-                        .with_message(format!("Perhaps you meant `{fix}'")),
-                );
+                diagnostic = diagnostic.with_suggestion(format!("Perhaps you meant `{fix}'"));
             }
             diagnostics.push(diagnostic);
         });

--- a/src/rules/rule01c.rs
+++ b/src/rules/rule01c.rs
@@ -46,6 +46,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Tree-sitter query for Rule I:C.
 const QUERY_STR: &str = indoc! { /* query */ r#"
     (
@@ -68,6 +70,16 @@ const QUERY_STR: &str = indoc! { /* query */ r#"
 pub struct Rule01c {}
 
 impl Rule for Rule01c {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 1,
+            letter: 'C',
+            code: "I:C",
+            name: "ConstantNaming",
+            description: "constants must use upper snake case and be >=2 characters",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut diagnostics = Vec::new();

--- a/src/rules/rule01d.rs
+++ b/src/rules/rule01d.rs
@@ -39,6 +39,8 @@ use crate::{
     rules::api::{Rule, SourceInfo},
 };
 
+use super::api::RuleDescription;
+
 /// Tree-sitter query for Rule I:D.
 const QUERY_STR: &str = indoc! {
     /* query */
@@ -67,6 +69,16 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule01d {}
 
 impl Rule for Rule01d {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 1,
+            letter: 'D',
+            code: "I:D",
+            name: "GlobalVariableNamingAndOrder",
+            description: "global variables must be prefixed with `g_` and global declarations must come before function definitions",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut first_function_position = None;

--- a/src/rules/rule02a.rs
+++ b/src/rules/rule02a.rs
@@ -42,6 +42,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Amount that wrapped lines must be indented, in columns.
 const WRAPPED_LINE_INDENT_WIDTH: usize = 2;
 
@@ -105,6 +107,16 @@ const QUERY_STR: &str = indoc! { /* query */ r##"
 "## };
 
 impl Rule for Rule02a {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 2,
+            letter: 'A',
+            code: "II:A",
+            name: "LineLength",
+            description: "lines must be 80 columns wide or less",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, lines }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 

--- a/src/rules/rule02b.rs
+++ b/src/rules/rule02b.rs
@@ -36,6 +36,8 @@ use crate::{
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Number of lines per page
 const PAGE_SIZE: usize = 61;
 /// Maximum number of pages a function definition may span
@@ -55,6 +57,16 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule02b {}
 
 impl Rule for Rule02b {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 2,
+            letter: 'B',
+            code: "II:B",
+            name: "FunctionLength",
+            description: "functions must be kept reasonably small",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut diagnostics = Vec::new();

--- a/src/rules/rule02b.rs
+++ b/src/rules/rule02b.rs
@@ -25,11 +25,11 @@
 //!               the function into smaller functions.
 //! ```
 
-use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
 use tree_sitter::QueryCapture;
 
 use crate::{
+    diagnostic::Diagnostic,
     helpers::{function_definition_name, QueryHelper},
     rules::api::Rule,
 };
@@ -67,7 +67,15 @@ impl Rule for Rule02b {
         }
     }
 
-    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
+    fn check<'a>(
+        &self,
+        SourceInfo {
+            filename,
+            tree,
+            code,
+            ..
+        }: &'a SourceInfo,
+    ) -> Vec<Diagnostic<'a>> {
         let helper = QueryHelper::new(QUERY_STR, tree, code);
         let mut diagnostics = Vec::new();
         helper.for_each_capture(|label: &str, capture: QueryCapture| match label {
@@ -81,13 +89,15 @@ impl Rule for Rule02b {
                         MAX_PAGES_PER_FUNCTION,
                         MAX_PAGES_PER_FUNCTION * PAGE_SIZE
                     );
-                    let diagnostic =
-                        Diagnostic::warning().with_code("II:B").with_message(message).with_label(
-                            Label::primary((), capture.node.byte_range()).with_message(format!(
+                    let diagnostic = Diagnostic::new(self.describe(), message)
+                        .with_violation_parts(
+                            filename,
+                            capture.node.into(),
+                            format!(
                                 "Function `{}()' is {} lines long",
                                 function_definition_name(capture.node, code),
                                 length
-                            )),
+                            ),
                         );
                     diagnostics.push(diagnostic);
                 }
@@ -100,9 +110,11 @@ impl Rule for Rule02b {
 
 #[cfg(test)]
 mod tests {
-    use crate::rules::api::{Rule, SourceInfo};
+    use crate::{
+        diagnostic::Diagnostic,
+        rules::api::{Rule, SourceInfo},
+    };
 
-    use codespan_reporting::diagnostic::{Diagnostic, Label};
     use pretty_assertions::assert_eq;
 
     use super::{Rule02b, MAX_PAGES_PER_FUNCTION, PAGE_SIZE};
@@ -119,20 +131,29 @@ mod tests {
 
         // Test for diagnostic
         let rule02b = Rule02b {};
-        let source = SourceInfo::new(&code);
+        let source = SourceInfo::new("", &code);
         assert_eq!(
             rule02b.check(&source),
-            vec![Diagnostic::warning()
-                .with_code("II:B")
-                .with_message(format!(
+            vec![Diagnostic::new(
+                rule02b.describe(),
+                format!(
                     "Functions must fit on {} pages, i.e. be no longer than {} lines",
                     MAX_PAGES_PER_FUNCTION,
                     PAGE_SIZE * MAX_PAGES_PER_FUNCTION
-                ))
-                .with_label(Label::primary((), 0..(code.len() - 1)).with_message(format!(
+                )
+            )
+            .with_violation_parts(
+                "",
+                crate::diagnostic::SourceRange {
+                    bytes: 0..(code.len() - 1),
+                    start_pos: (0, 0),
+                    end_pos: (code.lines().count(), 0)
+                },
+                format!(
                     "Function `main()' is {} lines long",
                     2 + MAX_PAGES_PER_FUNCTION * PAGE_SIZE
-                )))]
+                )
+            )]
         );
     }
 }

--- a/src/rules/rule03a.rs
+++ b/src/rules/rule03a.rs
@@ -32,6 +32,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Tree-sitter query for Rule III:A.
 const QUERY_STR: &str = indoc! {
     /* query */
@@ -90,6 +92,16 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule03a {}
 
 impl Rule for Rule03a {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 3,
+            letter: 'A',
+            code: "III:A",
+            name: "FlowControlSpacing",
+            description: "one space must be placed between flow control constructs",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 

--- a/src/rules/rule03b.rs
+++ b/src/rules/rule03b.rs
@@ -30,10 +30,10 @@
 //!       Example: *value = head->data;
 //! ```
 
-use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
 use tree_sitter::Node;
 
+use crate::diagnostic::{Diagnostic, SourceRange};
 use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
@@ -109,7 +109,15 @@ impl Rule for Rule03b {
         }
     }
 
-    fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
+    fn check<'a>(
+        &self,
+        SourceInfo {
+            filename,
+            tree,
+            code,
+            ..
+        }: &'a SourceInfo,
+    ) -> Vec<Diagnostic<'a>> {
         let mut diagnostics = Vec::new();
 
         // Binary expressions
@@ -122,7 +130,7 @@ impl Rule for Rule03b {
             let prev = helper.expect_node_for_capture_index(qmatch, prev_capture_i);
             let op = helper.expect_node_for_capture_index(qmatch, op_capture_i);
             let next = helper.expect_node_for_capture_index(qmatch, next_capture_i);
-            if let Some(diagnostic) = check_binary_op_spacing(op, prev, next, code) {
+            if let Some(diagnostic) = self.check_binary_op_spacing(op, prev, next, filename, code) {
                 diagnostics.push(diagnostic);
             }
         });
@@ -138,10 +146,11 @@ impl Rule for Rule03b {
             // Nodes must be adjacent
             if op.end_byte() != next.start_byte() {
                 diagnostics.push(
-                    Diagnostic::warning()
-                        .with_code("III:B")
-                        .with_message("Expected no space after unary operator")
-                        .with_label(Label::primary((), op.end_byte()..next.start_byte())),
+                    self.report("Expected no space after unary operator").with_violation_parts(
+                        filename,
+                        SourceRange::end_to_start(op, next),
+                        "", // FIXME: empty label is ugly
+                    ),
                 );
             }
         });
@@ -161,10 +170,11 @@ impl Rule for Rule03b {
             // Nodes must be adjacent
             if prev.end_byte() != lbrack.start_byte() {
                 diagnostics.push(
-                    Diagnostic::warning()
-                        .with_code("III:B")
-                        .with_message("Expected no space before array subscript")
-                        .with_label(Label::primary((), prev.end_byte()..lbrack.start_byte())),
+                    self.report("Expected no space before array subscript").with_violation_parts(
+                        filename,
+                        SourceRange::end_to_start(prev, lbrack),
+                        "", // FIXME: empty label is ugly
+                    ),
                 );
             }
         });
@@ -179,7 +189,7 @@ impl Rule for Rule03b {
             let prev = helper.expect_node_for_capture_index(qmatch, prev_capture_i);
             let op = helper.expect_node_for_capture_index(qmatch, op_capture_i);
             let next = helper.expect_node_for_capture_index(qmatch, next_capture_i);
-            if let Some(diagnostic) = check_field_op_spacing(op, prev, next) {
+            if let Some(diagnostic) = self.check_field_op_spacing(op, prev, next, filename) {
                 diagnostics.push(diagnostic);
             }
         });
@@ -188,72 +198,99 @@ impl Rule for Rule03b {
     }
 }
 
-/// Checks the spacing around a binary operator. Returns a [Diagnostic] if the spacing is
-/// incorrect. Otherwise returns [None].
-fn check_binary_op_spacing(
-    op: Node,
-    left: Node,
-    right: Node,
-    code: &str,
-) -> Option<Diagnostic<()>> {
-    // If the adjacent items are on the same line, check that there's a single space between them.
-    // If they're on separate lines, we do nothing, and leave it to Rule II:A to check the
-    // indentation.
-    let left_bad = left.end_position().row == op.start_position().row
-        && !is_single_space_between(left, op, code);
-    let right_bad = op.end_position().row == right.start_position().row
-        && !is_single_space_between(op, right, code);
-    let (message, range) = match (left_bad, right_bad) {
-        (true, true) => (
-            "Expected a single space on each side of binary operator",
-            left.end_byte()..right.start_byte(),
-        ),
-        (true, false) => {
-            ("Expected a single space before binary operator", left.end_byte()..op.end_byte())
-        }
-        (false, true) => (
-            "Expected a single space after binary operator",
-            op.start_byte()..right.start_byte(),
-        ),
-        (false, false) => return None,
-    };
-    Some(
-        Diagnostic::warning()
-            .with_code("III:B")
-            .with_message(message)
-            .with_label(Label::primary((), range)),
-    )
-}
+impl Rule03b {
+    /// Checks the spacing around a binary operator. Returns a [Diagnostic] if the spacing is
+    /// incorrect. Otherwise returns [None].
+    fn check_binary_op_spacing<'a>(
+        &self,
+        op: Node,
+        left: Node,
+        right: Node,
+        filename: &'a str,
+        code: &str,
+    ) -> Option<Diagnostic<'a>> {
+        // If the adjacent items are on the same line, check that there's a single space between them.
+        // If they're on separate lines, we do nothing, and leave it to Rule II:A to check the
+        // indentation.
+        let left_bad = left.end_position().row == op.start_position().row
+            && !is_single_space_between(left, op, code);
+        let right_bad = op.end_position().row == right.start_position().row
+            && !is_single_space_between(op, right, code);
+        let (message, range) = match (left_bad, right_bad) {
+            (true, true) => (
+                "Expected a single space on each side of binary operator",
+                SourceRange {
+                    bytes: left.end_byte()..right.start_byte(),
+                    start_pos: (left.end_position().row, left.end_position().column),
+                    end_pos: (right.start_position().row, right.start_position().column),
+                },
+            ),
+            (true, false) => (
+                "Expected a single space before binary operator",
+                SourceRange {
+                    bytes: left.end_byte()..op.end_byte(),
+                    start_pos: (left.end_position().row, left.end_position().column),
+                    end_pos: (op.end_position().row, op.end_position().column),
+                },
+            ),
+            (false, true) => (
+                "Expected a single space after binary operator",
+                SourceRange {
+                    bytes: op.start_byte()..right.start_byte(),
+                    start_pos: (op.start_position().row, op.start_position().column),
+                    end_pos: (right.start_position().row, right.start_position().column),
+                },
+            ),
+            (false, false) => return None,
+        };
+        // FIXME: empty string is ugly
+        Some(self.report(message).with_violation_parts(filename, range, ""))
+    }
 
-/// Checks the spacing around a field access operator. Returns a [Diagnostic] if the spacing is
-/// incorrect. Otherwise returns [None].
-fn check_field_op_spacing(op: Node, left: Node, right: Node) -> Option<Diagnostic<()>> {
-    // If the adjacent items are on the same line, check that there's a single space between them.
-    // If they're on separate lines, we do nothing, and leave it to Rule II:A to check the
-    // indentation.
-    let left_bad = left.end_byte() != op.start_byte();
-    let right_bad = op.end_byte() != right.start_byte();
-    let (message, range) = match (left_bad, right_bad) {
-        (true, true) => (
-            "Expected no space around field access operator",
-            left.end_byte()..right.start_byte(),
-        ),
-        (true, false) => (
-            "Expected no space before field access operator",
-            left.end_byte()..op.start_byte(),
-        ),
-        (false, true) => (
-            "Expected no space after field access operator",
-            op.end_byte()..right.start_byte(),
-        ),
-        (false, false) => return None,
-    };
-    Some(
-        Diagnostic::warning()
-            .with_code("III:B")
-            .with_message(message)
-            .with_label(Label::primary((), range)),
-    )
+    /// Checks the spacing around a field access operator. Returns a [Diagnostic] if the spacing is
+    /// incorrect. Otherwise returns [None].
+    fn check_field_op_spacing<'a>(
+        &self,
+        op: Node,
+        left: Node,
+        right: Node,
+        filename: &'a str,
+    ) -> Option<Diagnostic<'a>> {
+        // If the adjacent items are on the same line, check that there's a single space between them.
+        // If they're on separate lines, we do nothing, and leave it to Rule II:A to check the
+        // indentation.
+        let left_bad = left.end_byte() != op.start_byte();
+        let right_bad = op.end_byte() != right.start_byte();
+        let (message, range) = match (left_bad, right_bad) {
+            (true, true) => (
+                "Expected no space around field access operator",
+                SourceRange {
+                    bytes: left.end_byte()..right.start_byte(),
+                    start_pos: (left.end_position().row, left.end_position().column),
+                    end_pos: (right.start_position().row, right.start_position().column),
+                },
+            ),
+            (true, false) => (
+                "Expected no space before field access operator",
+                SourceRange {
+                    bytes: left.end_byte()..op.start_byte(),
+                    start_pos: (left.end_position().row, left.end_position().column),
+                    end_pos: (op.start_position().row, op.start_position().column),
+                },
+            ),
+            (false, true) => (
+                "Expected no space after field access operator",
+                SourceRange {
+                    bytes: op.end_byte()..right.start_byte(),
+                    start_pos: (op.end_position().row, op.end_position().column),
+                    end_pos: (right.start_position().row, right.start_position().column),
+                },
+            ),
+            (false, false) => return None,
+        };
+        // FIXME: empty string is ugly
+        Some(self.report(message).with_violation_parts(filename, range, ""))
+    }
 }
 
 /// Returns `true` if there is a single space separating the two nodes, else `false`.

--- a/src/rules/rule03b.rs
+++ b/src/rules/rule03b.rs
@@ -38,6 +38,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Tree-sitter query to capture binary expressions/operators.
 const QUERY_STR_BINARY: &str = indoc! {
     /* query */
@@ -97,6 +99,16 @@ const QUERY_STR_FIELD: &str = indoc! {
 pub struct Rule03b {}
 
 impl Rule for Rule03b {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 3,
+            letter: 'B',
+            code: "III:B",
+            name: "OperatorSpacing",
+            description: "operators must be spaced correctly",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 

--- a/src/rules/rule03c.rs
+++ b/src/rules/rule03c.rs
@@ -30,6 +30,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Tree-sitter query for Rule III:C.
 const QUERY_STR: &str = indoc! {
     /* query */
@@ -65,6 +67,16 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule03c {}
 
 impl Rule for Rule03c {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 3,
+            letter: 'C',
+            code: "III:C",
+            name: "InternalCommasAndSemicolons",
+            description: "one space must be placed after internal semicolons and commas",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
         let helper = QueryHelper::new(QUERY_STR, tree, code);

--- a/src/rules/rule03d.rs
+++ b/src/rules/rule03d.rs
@@ -54,6 +54,8 @@ use crate::{
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Tree-sitter query for Rule III:D.
 const QUERY_STR: &str = indoc! {
     /* query */
@@ -75,6 +77,16 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule03d {}
 
 impl Rule for Rule03d {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 3,
+            letter: 'D',
+            code: "III:D",
+            name: "PreprocessorDefinitionLocationSpacing",
+            description: "#defines must be grouped together between blank lines",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, lines }: &SourceInfo) -> Vec<Diagnostic<()>> {
         // List of function definition bodies
         let mut function_bodies: Vec<Node> = Vec::new();

--- a/src/rules/rule03d.rs
+++ b/src/rules/rule03d.rs
@@ -43,12 +43,12 @@
 
 use std::ops::Range;
 
-use codespan_reporting::diagnostic::{Diagnostic, Label};
 use indoc::indoc;
 use tree_sitter::{Node, Range as TSRange};
 
 use crate::{
-    helpers::{function_definition_name, QueryHelper, RangeCollapser},
+    diagnostic::{Diagnostic, SourceRange, Span},
+    helpers::{function_definition_name, line_width, QueryHelper, RangeCollapser},
     rules::api::Rule,
 };
 
@@ -87,7 +87,13 @@ impl Rule for Rule03d {
         }
     }
 
-    fn check(&self, SourceInfo { tree, code, lines }: &SourceInfo) -> Vec<Diagnostic<()>> {
+    fn check<'a>(&self, source: &'a SourceInfo) -> Vec<Diagnostic<'a>> {
+        let SourceInfo {
+            filename,
+            tree,
+            code,
+            lines,
+        } = source;
         // List of function definition bodies
         let mut function_bodies: Vec<Node> = Vec::new();
         // List of #define statements
@@ -127,15 +133,12 @@ impl Rule for Rule03d {
                 let print_range =
                     range_without_trailing_eol(group.start_byte..group.end_byte, code);
                 diagnostics.push(
-                    Diagnostic::warning()
-                        .with_code("III:D")
-                        .with_message("Global preprocessor definitions must be placed at the top of the file, before all functions")
-                        .with_label(
-                            Label::primary((), print_range).with_message("Macro(s) defined here")
+                    self.report("Global preprocessor definitions must be placed at the top of the file, before all functions")
+                        .with_violation_parts(
+                            filename, SourceRange::from_byte_range(print_range, source), "Macro(s) defined here"
                         )
-                        .with_label(
-                            // SAFETY: We've already checked that first_func.is_some_and(...).
-                            Label::secondary((), first_func.unwrap().byte_range()).with_message("First function defined here")
+                        .with_reference_parts(
+                            filename, first_func.unwrap().into(), "First function defined here"
                         )
                 );
             }
@@ -144,22 +147,36 @@ impl Rule for Rule03d {
         // Check that global #define statements are grouped together
         if global_define_groups.len() > 1 {
             diagnostics.push(
-                Diagnostic::warning()
-                    .with_code("III:D")
-                    .with_message("All top-level #define statements must be grouped together")
-                    .with_labels_iter(global_define_groups.into_iter().enumerate().map(
-                        |(i, group)| {
-                            let range =
-                                range_without_trailing_eol(group.start_byte..group.end_byte, code);
-                            if i == 0 {
-                                Label::secondary((), range)
-                                    .with_message("First group of #define statements found here")
-                            } else {
-                                Label::primary((), range)
-                                    .with_message("More #define statements found here")
-                            }
-                        },
-                    )),
+                self.report("All top-level #define statements must be grouped together")
+                    .with_reference_parts(
+                        filename,
+                        SourceRange::from_byte_range(
+                            range_without_trailing_eol(
+                                global_define_groups[0].start_byte
+                                    ..global_define_groups[0].end_byte,
+                                code,
+                            ),
+                            source,
+                        ),
+                        "First group of #define statements found here",
+                    )
+                    .with_violations(
+                        global_define_groups
+                            .iter()
+                            .skip(1)
+                            .map(|group| {
+                                let range = range_without_trailing_eol(
+                                    group.start_byte..group.end_byte,
+                                    code,
+                                );
+                                Span::new(
+                                    filename,
+                                    SourceRange::from_byte_range(range, source),
+                                    "More #define statements found here",
+                                )
+                            })
+                            .collect(),
+                    ),
             );
         }
 
@@ -177,27 +194,45 @@ impl Rule for Rule03d {
                 let function_def =
                     function.parent().expect("Expected function body to have a parent");
                 let function_name = function_definition_name(function_def, code);
+                let function_decl = function_def
+                    .child_by_field_name("declarator")
+                    .expect("Expected function definition to have a declarator");
                 diagnostics.push(
-                    Diagnostic::warning()
-                        .with_code("III:D")
-                        .with_message(
-                            "All #define statements in each function must be grouped together",
+                    self.report("All #define statements in each function must be grouped together")
+                        .with_reference_parts(
+                            filename,
+                            function_decl.into(),
+                            format!("In function `{function_name}()'"),
                         )
-                        .with_notes(vec![format!("In function `{}()'", function_name)])
-                        .with_labels_iter(groups_in_function.into_iter().enumerate().map(
-                            |(i, define_group)| {
-                                let range = define_group.start_byte..define_group.end_byte;
-                                let print_range = range_without_trailing_eol(range, code);
-                                if i == 0 {
-                                    Label::secondary((), print_range).with_message(
-                                        "First group of #define statements found here",
+                        .with_reference_parts(
+                            filename,
+                            SourceRange::from_byte_range(
+                                range_without_trailing_eol(
+                                    groups_in_function[0].start_byte
+                                        ..groups_in_function[0].end_byte,
+                                    code,
+                                ),
+                                source,
+                            ),
+                            "First group of #define statements found here",
+                        )
+                        .with_violations(
+                            groups_in_function
+                                .iter()
+                                .skip(1)
+                                .map(|define_group| {
+                                    let range = range_without_trailing_eol(
+                                        define_group.start_byte..define_group.end_byte,
+                                        code,
+                                    );
+                                    Span::new(
+                                        filename,
+                                        SourceRange::from_byte_range(range, source),
+                                        "More #define statements found here",
                                     )
-                                } else {
-                                    Label::primary((), print_range)
-                                        .with_message("More #define statements found here")
-                                }
-                            },
-                        )),
+                                })
+                                .collect(),
+                        ),
                 );
             }
         }
@@ -248,13 +283,16 @@ impl Rule for Rule03d {
                 // Missing blank line before only.
                 (false, true) => {
                     diagnostics.push(
-                        Diagnostic::warning()
-                            .with_code("III:D")
-                            .with_message("Expected blank line before #define statement(s)")
-                            .with_label(Label::primary((), print_range.clone()))
-                            .with_label(
-                                Label::secondary((), prev_line_range.unwrap())
-                                    .with_message("Previous line is non-blank"),
+                        self.report("Expected blank line before #define statement(s)")
+                            .with_violation_parts(
+                                filename,
+                                SourceRange::from_byte_range(print_range.clone(), source),
+                                "",
+                            )
+                            .with_reference_parts(
+                                filename,
+                                SourceRange::from_byte_range(prev_line_range.unwrap(), source),
+                                "Previous line is non-blank",
                             ),
                     );
                 }
@@ -262,13 +300,16 @@ impl Rule for Rule03d {
                 // Missing blank line after only.
                 (true, false) => {
                     diagnostics.push(
-                        Diagnostic::warning()
-                            .with_code("III:D")
-                            .with_message("Expected blank line after #define statement(s)")
-                            .with_label(Label::primary((), print_range))
-                            .with_label(
-                                Label::secondary((), next_line_range.unwrap())
-                                    .with_message("Next line is non-blank"),
+                        self.report("Expected blank line after #define statement(s)")
+                            .with_violation_parts(
+                                filename,
+                                SourceRange::from_byte_range(print_range.clone(), source),
+                                "",
+                            )
+                            .with_reference_parts(
+                                filename,
+                                SourceRange::from_byte_range(next_line_range.unwrap(), source),
+                                "Next line is non-blank",
                             ),
                     );
                 }
@@ -276,17 +317,21 @@ impl Rule for Rule03d {
                 // Missing blank lines before and after.
                 (false, false) => {
                     diagnostics.push(
-                        Diagnostic::warning()
-                            .with_code("III:D")
-                            .with_message("Expected blank lines surrounding #define statement(s)")
-                            .with_label(Label::primary((), print_range))
-                            .with_label(
-                                Label::secondary((), prev_line_range.unwrap())
-                                    .with_message("Previous line is non-blank"),
+                        self.report("Expected blank lines surrounding #define statement(s)")
+                            .with_violation_parts(
+                                filename,
+                                SourceRange::from_byte_range(print_range, source),
+                                "",
                             )
-                            .with_label(
-                                Label::secondary((), next_line_range.unwrap())
-                                    .with_message("Next line is non-blank"),
+                            .with_reference_parts(
+                                filename,
+                                SourceRange::from_byte_range(prev_line_range.unwrap(), source),
+                                "Previous line is non-blank",
+                            )
+                            .with_reference_parts(
+                                filename,
+                                SourceRange::from_byte_range(next_line_range.unwrap(), source),
+                                "Next line is non-blank",
                             ),
                     );
                 }
@@ -332,7 +377,7 @@ mod tests {
             "
         };
         let rule = Rule03d {};
-        let source = SourceInfo::new(code);
+        let source = SourceInfo::new("", code);
         let diagnostics = rule.check(&source);
         // Expect 1 diagnostic for the whole group.
         assert_eq!(1, diagnostics.len());
@@ -343,11 +388,14 @@ mod tests {
     #[test]
     fn no_eol() {
         let code = "// comment\n#define A";
-        let source = SourceInfo::new(code);
+        let source = SourceInfo::new("", code);
         let rule = Rule03d {};
         let diagnostics = rule.check(&source);
         assert_eq!(1, diagnostics.len());
-        assert_eq!(code.lines().last().unwrap(), &code[diagnostics[0].labels[0].range.clone()]);
+        assert_eq!(
+            code.lines().last().unwrap(),
+            &code[diagnostics[0].violations[0].range.bytes.clone()]
+        );
     }
 
     /// Ensures that the logic for blank line checking does not fail if there is no line before or
@@ -355,7 +403,7 @@ mod tests {
     #[test]
     fn file_start_end() {
         let code = "#define A\n";
-        let source = SourceInfo::new(code);
+        let source = SourceInfo::new("", code);
         let rule = Rule03d {};
         let diagnostics = rule.check(&source);
         assert!(diagnostics.is_empty());
@@ -367,14 +415,14 @@ mod tests {
     fn crlf() {
         let code = "/* comment */\r\n#define A 1\r\n";
         let rule = Rule03d {};
-        let source = SourceInfo::new(code);
+        let source = SourceInfo::new("", code);
         let diagnostics = rule.check(&source);
         // Sanity checks
         assert_eq!(1, diagnostics.len());
-        assert_eq!(LabelStyle::Primary, diagnostics[0].labels[0].style);
+        assert_eq!(1, diagnostics[0].violations.len());
         // str::lines() excludes the CRLF.
         let expected_line = code.lines().nth(1).unwrap();
-        let actual_line = &code[diagnostics[0].labels[0].range.clone()];
+        let actual_line = &code[diagnostics[0].violations[0].range.bytes.clone()];
         assert_eq!(expected_line, actual_line);
     }
 }

--- a/src/rules/rule03e.rs
+++ b/src/rules/rule03e.rs
@@ -24,12 +24,24 @@ use crate::rules::api::Rule;
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// # Rule III:E.
 ///
 /// See module-level documentation for details.
 pub struct Rule03e {}
 
 impl Rule for Rule03e {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 3,
+            letter: 'E',
+            code: "III:E",
+            name: "TrailingWhitespace",
+            description: "lines must not have trailing whitespace",
+        }
+    }
+
     fn check(&self, SourceInfo { lines, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
         for (line, index) in lines {

--- a/src/rules/rule03e.rs
+++ b/src/rules/rule03e.rs
@@ -18,8 +18,9 @@
 //!    C. Never put trailing whitespace at the end of a line.
 //! ```
 
-use codespan_reporting::diagnostic::{Diagnostic, Label};
-
+use crate::diagnostic::Diagnostic;
+use crate::diagnostic::SourceRange;
+use crate::helpers::line_width;
 use crate::rules::api::Rule;
 
 use crate::rules::api::SourceInfo;
@@ -42,19 +43,29 @@ impl Rule for Rule03e {
         }
     }
 
-    fn check(&self, SourceInfo { lines, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
+    fn check<'a>(
+        &self,
+        SourceInfo {
+            filename, lines, ..
+        }: &'a SourceInfo,
+    ) -> Vec<Diagnostic<'a>> {
         let mut diagnostics = Vec::new();
-        for (line, index) in lines {
+        for &(line, index) in lines {
             let trimmed_line = line.trim_end();
             if trimmed_line.len() != line.len() {
                 // Start/end of trailing whitespace
                 let start = index + trimmed_line.len();
                 let end = index + line.len();
                 diagnostics.push(
-                    Diagnostic::warning()
-                        .with_code("III:E")
-                        .with_message("Line contains trailing whitespace")
-                        .with_label(Label::primary((), start..end)),
+                    self.report("Line contains trailing whitespace").with_violation_parts(
+                        filename,
+                        SourceRange {
+                            bytes: start..end,
+                            start_pos: (index, line_width(trimmed_line)),
+                            end_pos: (index, line_width(line)),
+                        },
+                        "",
+                    ),
                 );
             }
         }
@@ -73,7 +84,7 @@ mod tests {
     #[test]
     fn rule03e() {
         let code = "int main() { \n  return 0;\t\n}\n";
-        let source = SourceInfo::new(code);
+        let source = SourceInfo::new("", code);
         let rule = Rule03e {};
         let diagnostics = rule.check(&source);
         assert_eq!(2, diagnostics.len());

--- a/src/rules/rule03f.rs
+++ b/src/rules/rule03f.rs
@@ -26,6 +26,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Tree-sitter query for Rule III:F.
 const QUERY_STR: &str = indoc! {
     /* query */
@@ -48,6 +50,16 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule03f {}
 
 impl Rule for Rule03f {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 3,
+            letter: 'F',
+            code: "III:F",
+            name: "NoSpaceBeforeParen",
+            description: "function calls must not have spaces",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
         let helper = QueryHelper::new(QUERY_STR, tree, code);

--- a/src/rules/rule11a.rs
+++ b/src/rules/rule11a.rs
@@ -131,7 +131,7 @@ mod tests {
     fn all_tabs() {
         let code = "#include <stdio.h>\nint main() {\n\t\tprintf(\"Hello, world!\\n\");\n\t\treturn 0;\n}\n";
         let rule = super::Rule11a::new(None);
-        let diagnostics = rule.check(&SourceInfo::new(code));
+        let diagnostics = rule.check(&SourceInfo::new("", code));
         assert_eq!(2, diagnostics.len());
         assert!(diagnostics.iter().all(|diag| diag.labels.len() == 1));
     }
@@ -141,7 +141,7 @@ mod tests {
     fn mix_tabs_spaces() {
         let code = "#include <stdio.h>\nint main() {\n  \tprintf(\"Hello, world!\\n\");\n  \treturn 0;\n}\n";
         let rule = super::Rule11a::new(None);
-        let diagnostics = rule.check(&SourceInfo::new(code));
+        let diagnostics = rule.check(&SourceInfo::new("", code));
         assert_eq!(2, diagnostics.len());
         assert!(diagnostics.iter().all(|diag| diag.labels.len() == 1));
         assert!(diagnostics.iter().all(|diag| diag.notes.len() == 1));
@@ -153,7 +153,7 @@ mod tests {
         let code =
             "#include <stdio.h>\nint main() {\n  printf(\"Hello, world!\\n\");\n  return 0;\n}\n";
         let rule = super::Rule11a::new(None);
-        let diagnostics = rule.check(&SourceInfo::new(code));
+        let diagnostics = rule.check(&SourceInfo::new("", code));
         assert!(diagnostics.is_empty());
     }
 }

--- a/src/rules/rule11a.rs
+++ b/src/rules/rule11a.rs
@@ -24,6 +24,8 @@ use crate::rules::api::Rule;
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// # Rule XI:A.
 ///
 /// See module-level documentation for details.
@@ -43,6 +45,16 @@ impl Rule11a {
 }
 
 impl Rule for Rule11a {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 11,
+            letter: 'A',
+            code: "XI:A",
+            name: "NoTabs",
+            description: "do not use tabs for indentation",
+        }
+    }
+
     fn check(&self, SourceInfo { lines, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 

--- a/src/rules/rule11b.rs
+++ b/src/rules/rule11b.rs
@@ -120,7 +120,7 @@ mod tests {
     fn has_crlf() {
         let code = "int main() {\r\n  return 0;\r\n}\r\n";
         let rule = super::Rule11b::new(None);
-        let diagnostics = rule.check(&SourceInfo::new(code));
+        let diagnostics = rule.check(&SourceInfo::new("", code));
         assert_eq!(3, diagnostics.len());
         let cr_positions: Vec<usize> = code
             .char_indices()
@@ -138,7 +138,7 @@ mod tests {
     fn no_crlf() {
         let code = "int main() {\n  return 0;\n}\n";
         let rule = super::Rule11b::new(None);
-        let diagnostics = rule.check(&SourceInfo::new(code));
+        let diagnostics = rule.check(&SourceInfo::new("", code));
         assert!(diagnostics.is_empty());
     }
 
@@ -147,7 +147,7 @@ mod tests {
     fn limit() {
         let code = "int main() {\r\n  return 0;\r\n}\r\n";
         let rule = super::Rule11b::new(Some(NonZeroUsize::new(1).unwrap()));
-        let diagnostics = rule.check(&SourceInfo::new(code));
+        let diagnostics = rule.check(&SourceInfo::new("", code));
         assert_eq!(1, diagnostics.len());
         assert_eq!(2, diagnostics[0].notes.len());
         // First note is Vim tip; second is remaining warnings.

--- a/src/rules/rule11b.rs
+++ b/src/rules/rule11b.rs
@@ -26,6 +26,8 @@ use crate::rules::api::Rule;
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// # Rule XI:B.
 ///
 /// See module-level documentation for details.
@@ -45,6 +47,16 @@ impl Rule11b {
 }
 
 impl Rule for Rule11b {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 11,
+            letter: 'B',
+            code: "XI:B",
+            name: "NoCRLF",
+            description: "do not use DOS-style newlines (\\r\\n)",
+        }
+    }
+
     fn check(&self, SourceInfo { code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 

--- a/src/rules/rule11e.rs
+++ b/src/rules/rule11e.rs
@@ -25,6 +25,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// Tree-sitter query for Rule XI:E.
 const QUERY_STR: &str = indoc! {
     /* query */
@@ -39,6 +41,16 @@ const QUERY_STR: &str = indoc! {
 pub struct Rule11e {}
 
 impl Rule for Rule11e {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 11,
+            letter: 'E',
+            code: "XI:E",
+            name: "NoGoto",
+            description: "do not use goto statements",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
         let helper = QueryHelper::new(QUERY_STR, tree, code);

--- a/src/rules/rule12a.rs
+++ b/src/rules/rule12a.rs
@@ -37,6 +37,8 @@ use crate::{helpers::QueryHelper, rules::api::Rule};
 
 use crate::rules::api::SourceInfo;
 
+use super::api::RuleDescription;
+
 /// # Rule XII:A.
 ///
 /// See module-level documentation for details.
@@ -64,6 +66,16 @@ const QUERY_STR: &str = indoc! {
 };
 
 impl Rule for Rule12a {
+    fn describe(&self) -> &'static RuleDescription {
+        &RuleDescription {
+            group_number: 12,
+            letter: 'A',
+            code: "XII:A",
+            name: "MultipleDefinitions",
+            description: "at most one variable may be defined on a single line",
+        }
+    }
+
     fn check(&self, SourceInfo { tree, code, .. }: &SourceInfo) -> Vec<Diagnostic<()>> {
         let mut diagnostics = Vec::new();
 


### PR DESCRIPTION
Replaces `codespan_reporting::diagnostic::Diagnostic` with a custom `Diagnostic` type. This will hopefully make it easier to support more output formats later on, such as SARIF or Checkstyle XML.